### PR TITLE
improve timeout future handling

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -110,7 +110,7 @@ public class MqttBrokerConnectionTests {
 
         ScheduledThreadPoolExecutor s = new ScheduledThreadPoolExecutor(1);
         a.setTimeoutExecutor(s, 10);
-        assertThat(a.getTimeoutExecutor(), is(s));
+        assertThat(a.timeoutExecutor, is(s));
 
         Semaphore semaphore = new Semaphore(1);
         semaphore.acquire();

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
@@ -92,7 +92,8 @@ public class MqttBrokerConnection {
 
     // Connection timeout handling
     final AtomicReference<@Nullable ScheduledFuture<?>> timeoutFuture = new AtomicReference<>(null);
-    private @Nullable ScheduledExecutorService timeoutExecutor;
+    @Nullable
+    ScheduledExecutorService timeoutExecutor;
     private int timeout = 1200; /* Connection timeout in milliseconds */
 
     /**
@@ -257,14 +258,6 @@ public class MqttBrokerConnection {
     public void setTimeoutExecutor(@Nullable ScheduledExecutorService executor, int timeoutInMS) {
         timeoutExecutor = executor;
         this.timeout = timeoutInMS;
-    }
-
-    public @Nullable Executor getTimeoutExecutor() {
-        return timeoutExecutor;
-    }
-
-    public int getTimeout() {
-        return timeout;
     }
 
     /**


### PR DESCRIPTION
* the future is currently not canceled on stop
* use a function for similar (identical) code
* use a atomic reference to be able to use "get and set" and to ensure
  the future reference is the current on if accessed from different
  threads.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>